### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
     "es6-promise": "^2.0.0",
     "forge": "~0.6.23",
     "jsonld": "~0.4.6",
-    "node-uuid": "~1.4.7"
   },
   "ignore": [
     "node_modules",

--- a/lib/did-io.js
+++ b/lib/did-io.js
@@ -55,7 +55,7 @@ var _browser = !_nodejs &&
  *          [inject] *deprecated*, use `use` API instead; the dependencies to
  *            inject, available global defaults will be used otherwise.
  *            [forge] forge API.
- *            [uuid] The node-uuid API.
+ *            [uuid] The uuid API.
  *            [jsonld] jsonld.js API; all remote documents will be loaded
  *              using jsonld.documentLoader by default, so ensure a secure
  *              document loader is configured.
@@ -128,7 +128,7 @@ api.use = function(name, injectable) {
         globalName = 'jsonldjs';
         break;
       case 'uuid':
-        requireName = 'node-uuid';
+        requireName = 'uuid';
         break;
     }
     libs[name] = global[globalName] || (_nodejs && require(requireName));

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "jsonld-signatures": "^1.1.5",
     "lodash": "^4.6.1",
     "node-forge": "~0.6.28",
-    "node-uuid": "^1.4.7",
-    "request": "^2.69.0"
+    "request": "^2.69.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/tests/test.js
+++ b/tests/test.js
@@ -48,7 +48,7 @@ if(_nodejs) {
   window.forge = forge;
   require('../node_modules/jsonld');
   var jsonld = jsonldjs;
-  var uuid = require('node-uuid');
+  var uuid = require('uuid');
   window.uuid = uuid;
   require('../' + _jsdir + '/did-io');
   var didio = window.didio;


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.