### PR TITLE
Properly handle documentLoader promise.

### DIFF
--- a/lib/did-io.js
+++ b/lib/did-io.js
@@ -230,6 +230,23 @@ api.getDidDocument = function(did, options, callback) {
   }
   var url = baseUrl + did;
   var jsonld = api.use('jsonld');
+
+  if(global.Promise) {
+    // jsonld document loader is going to return a promise
+    return jsonld.documentLoader(url).then(function(doc) {
+      doc = doc.document;
+      if(typeof doc === 'string') {
+        try {
+          doc = JSON.parse(doc);
+        } catch(e) {}
+      }
+      callback(null, doc);
+    }).catch(function(err) {
+      err.status = err.httpStatusCode || 404;
+      callback(err);
+    });
+  }
+
   jsonld.documentLoader(url, function(err, doc) {
     if(err) {
       err.status = err.httpStatusCode || 404;


### PR DESCRIPTION
if `global.Promise` is defined, `jsonld.documentLoader` will ignore a passed in callback and return a promise.

This surfaced in a module that calls `didio.promises.getDidDocument`

This is starting point to discuss the best solution.