### PR TITLE
Add conditional around `importKeys`.

### DIFF
--- a/lib/methods/veres-one/veres-one.js
+++ b/lib/methods/veres-one/veres-one.js
@@ -43,7 +43,10 @@ class VeresOne {
     const result = await this.client.get({did, mode, hostname});
     const didDoc = new VeresOneDidDoc({injector: this.injector, ...result});
     const keysData = await this.keyStore.get(did);
-    didDoc.importKeys(keysData);
+
+    if(keysData) {
+      didDoc.importKeys(keysData);
+    }
 
     if(autoObserve) {
       didDoc.observe();


### PR DESCRIPTION
I found that if I'm doing a `v1.get` on a DID that was not generated by this library and is therefore not in storage that the call the `this.keyStore.get` on L45 returns `null`.   `null` is not an acceptable value in the `importKeys` API which results in an uncaught error.

I don't know if this is the proper solution, but it is what I'm using as a workaround.