### PR TITLE
Expand client.get() to handle subgraph (key id) requests.

### DIFF
--- a/lib/methods/veres-one/client.js
+++ b/lib/methods/veres-one/client.js
@@ -5,6 +5,7 @@
 
 const url = require('url');
 const r2 = require('r2');
+const jsonld = require('jsonld');
 // const https = require('https');
 
 const DEFAULT_LOCATION = 'ledger';
@@ -16,9 +17,10 @@ class VeresOneClient {
   }
 
   /**
-   * Fetches a DID Document for a given DID.
+   * Fetches a DID Document for a given DID. If it contains a #hash fragment,
+   * it's likely a key id, so just return the subgraph, not the full doc.
    *
-   * @param did {string}
+   * @param did {string} DID uri (possibly with hash fragment)
    * @param [mode] {string} One of 'dev'/'test'/'live'
    * @param [hostname] {string} Optional hostname of ledger (falls back
    *   to the default hostname for a particular mode)
@@ -26,9 +28,14 @@ class VeresOneClient {
    * @returns {Promise<object>} Resolves to DID Document Fetch Result
    */
   async get({did, mode, hostname}) {
+    if(!did) {
+      throw new Error('Invalid or missing DID URI');
+    }
+    const [docUri, hashFragment] = did.split('#');
+
     const ledgerAgent = await this.getAgent({mode, hostname});
     const queryServiceUrl = url.parse(ledgerAgent.service.ledgerQueryService);
-    queryServiceUrl.search = `id=${did}`;
+    queryServiceUrl.search = `id=${docUri}`;
     const didUrl = url.format(queryServiceUrl);
 
     // const https = require('https');
@@ -61,12 +68,30 @@ class VeresOneClient {
       // reqMs,
       // start: reqOptions.start,
       // retries: reqOptions.retries + 1,
-      type: 'LedgerDidDocument',
-      did,
+      did: docUri,
       // hostname,
-      doc: body.object,
       meta: body.meta
     };
+
+    const didDoc = body.object;
+
+    if(!hashFragment) {
+      // full DID Doc
+      result.type = 'LedgerDidDocument';
+      result.doc = didDoc;
+    } else {
+      // Request for a subgraph (likely just the key node)
+      const map = await jsonld.createNodeMap(didDoc);
+      const subGraph = map[did];
+      if(!subGraph) {
+        throw new Error('Failed to get subgraph within a DID Document, uri:',
+          did);
+      }
+      subGraph['@context'] = didDoc['@context'];
+
+      // result.type = 'Key'; <- not sure what this should be
+      result.doc = subGraph;
+    }
 
     return result;
   }

--- a/lib/methods/veres-one/client.js
+++ b/lib/methods/veres-one/client.js
@@ -74,6 +74,7 @@ class VeresOneClient {
     };
 
     const didDoc = body.object;
+    const context = didDoc['@context'];
 
     if(!hashFragment) {
       // full DID Doc
@@ -87,10 +88,9 @@ class VeresOneClient {
         throw new Error('Failed to get subgraph within a DID Document, uri:',
           did);
       }
-      subGraph['@context'] = didDoc['@context'];
 
       // result.type = 'Key'; <- not sure what this should be
-      result.doc = subGraph;
+      result.doc = await jsonld.compact(subGraph, context);
     }
 
     return result;

--- a/tests/veres-one/client.spec.js
+++ b/tests/veres-one/client.spec.js
@@ -52,6 +52,41 @@ describe('did methods', () => {
         expect(result.doc.id).to.equal(TEST_DID);
         expect(result.meta.sequence).to.equal(0);
       });
+
+      it('should fetch just a key object from a did: with hash', async () => {
+        nock('https://genesis.testnet.veres.one')
+          .get(`/ledger-agents`)
+          .reply(200, LEDGER_AGENTS_DOC);
+
+        nock('https://genesis.testnet.veres.one')
+          .post('/ledger-agents/72fdcd6a-5861-4307-ba3d-cbb72509533c' +
+            '/query?id=' + TEST_DID)
+          .reply(200, TEST_DID_RESULT);
+
+        const testKeyId = TEST_DID + '#authn-key-1';
+
+        const expectedDoc = {
+          "@id": "did:v1:test:nym:2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX#authn-key-1",
+          "@type": [
+            "https://w3id.org/security#Ed25519VerificationKey2018"
+          ],
+          "https://w3id.org/security#owner": [
+            {
+              "@id": "did:v1:test:nym:2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX"
+            }
+          ],
+          "https://w3id.org/security#publicKeyBase58": [
+            {
+              "@value": "2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX"
+            }
+          ],
+          "@context": "https://w3id.org/veres-one/v1"
+        };
+
+        const result = await client.get({did: testKeyId});
+
+        expect(result.doc).to.eql(expectedDoc);
+      });
     });
 
     describe('sendToAccelerator', () => {

--- a/tests/veres-one/client.spec.js
+++ b/tests/veres-one/client.spec.js
@@ -66,21 +66,11 @@ describe('did methods', () => {
         const testKeyId = TEST_DID + '#authn-key-1';
 
         const expectedDoc = {
-          "@id": "did:v1:test:nym:2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX#authn-key-1",
-          "@type": [
-            "https://w3id.org/security#Ed25519VerificationKey2018"
-          ],
-          "https://w3id.org/security#owner": [
-            {
-              "@id": "did:v1:test:nym:2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX"
-            }
-          ],
-          "https://w3id.org/security#publicKeyBase58": [
-            {
-              "@value": "2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX"
-            }
-          ],
-          "@context": "https://w3id.org/veres-one/v1"
+          "@context": "https://w3id.org/veres-one/v1",
+          "id": "did:v1:test:nym:2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX#authn-key-1",
+          "type": "Ed25519VerificationKey2018",
+          "owner": "did:v1:test:nym:2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX",
+          "publicKeyBase58": "2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX"
         };
 
         const result = await client.get({did: testKeyId});


### PR DESCRIPTION
Usage:

```
await client.get({did: 'did:v1:test:nym:2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX#authn-key-1'})

// -> 
{
  "found": true,
  "retry": false,
  "did": "did:v1:test:nym:2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX",
  "meta": {
    "blockHeight": 46,
    "created": 1521470999238,
    "updated": 1521470999238,
    "sequence": 0
  },
  "doc": {
          "@context": "https://w3id.org/veres-one/v1",
          "id": "did:v1:test:nym:2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX#authn-key-1",
          "type": "Ed25519VerificationKey2018",
          "owner": "did:v1:test:nym:2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX",
          "publicKeyBase58": "2pfPix2tcwa7gNoMRxdcHbEyFGqaVBPNntCsDZexVeHX"
        }
}
```