### PR TITLE
Rename secretKey to privateKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # did-io ChangeLog
 
+## 0.8.0
+(Migrating from v0.7.0 will require renaming the relevant properties in existing
+DID Docs.)
+
+## Changed
+
+- **BREAKING**: Updated terminology to match latest VeresOne DID method specs:
+  `grantCapability -> capabilityDelegation`,
+  `invokeCapability -> capabilityInvocation`
+- **BREAKING**: Renamed `secretKey` to `privateKey`, to match Digital
+  Bazaar conventions.
+
 ## 0.7.0 - 2018-09-10
 
 ## Changed (BREAKING changes)

--- a/lib/ld-key-pair.js
+++ b/lib/ld-key-pair.js
@@ -16,7 +16,7 @@ class LDKeyPair {
     this.injector = options.injector || new Injector();
     this.keyType = options.keyType;
     this.publicKey = options.publicKey;
-    this.secretKey = options.secretKey;
+    this.privateKey = options.privateKey;
     this.passphrase = options.passphrase || null;
     this.id = options.id;
   }
@@ -95,7 +95,7 @@ class Ed25519KeyPair extends LDKeyPair {
 
     const keys = new Ed25519KeyPair({
       publicKey: bs58.encode(keyPair.publicKey),
-      secretKey: bs58.encode(keyPair.secretKey),
+      privateKey: bs58.encode(keyPair.secretKey),
       ...options
     });
 
@@ -105,7 +105,7 @@ class Ed25519KeyPair extends LDKeyPair {
   static async from(data, options) {
     const keyPair = new Ed25519KeyPair({
       publicKey: data.publicKeyBase58,
-      secretKey: data.secretKeyBase58,
+      privateKey: data.privateKeyBase58,
       id: data.id,
       keyType: data.keyType,
       ...options
@@ -122,7 +122,7 @@ class Ed25519KeyPair extends LDKeyPair {
       publicKeyBase58: this.publicKey
     };
 
-    return this.addEncryptedSecretKey(keyNode);
+    return this.addEncryptedPrivateKey(keyNode);
   }
 
   addEncodedPublicKey(publicKeyNode) {
@@ -130,24 +130,24 @@ class Ed25519KeyPair extends LDKeyPair {
     return publicKeyNode;
   }
 
-  async addEncryptedSecretKey(keyNode) {
+  async addEncryptedPrivateKey(keyNode) {
     if(this.passphrase !== null) {
-      keyNode.secretKeyJwe = await this.encrypt({secretKeyBase58: this.secretKey},
+      keyNode.privateKeyJwe = await this.encrypt({privateKeyBase58: this.privateKey},
         this.passphrase);
     } else {
       // no passphrase, do not encrypt private key
-      keyNode.secretKeyBase58 = this.secretKey;
+      keyNode.privateKeyBase58 = this.privateKey;
     }
     return keyNode;
   }
 
   /**
-   * @param secretKey
+   * @param privateKey
    * @param password
    *
    * @returns {Promise<JWE>}
    */
-  async encrypt(secretKey, password) {
+  async encrypt(privateKey, password) {
     const keySize = 32;
     const salt = forge.random.getBytesSync(32);
     const iterations = 4096;
@@ -168,7 +168,7 @@ class Ed25519KeyPair extends LDKeyPair {
     const iv = forge.random.getBytesSync(12);
     const cipher = forge.cipher.createCipher('AES-GCM', key);
     cipher.start({iv});
-    cipher.update(forge.util.createBuffer(JSON.stringify(secretKey)));
+    cipher.update(forge.util.createBuffer(JSON.stringify(privateKey)));
     cipher.finish();
     const encrypted = cipher.output.getBytes();
     const tag = cipher.mode.tag.getBytes();
@@ -222,7 +222,7 @@ class RSAKeyPair extends LDKeyPair {
       const ursa = require('ursa');
       const keyPair = ursa.generatePrivateKey(keyBits, exponent);
       return new RSAKeyPair({
-        secretKey: forge.pki.privateKeyFromPem(keyPair.toPrivatePem()),
+        privateKey: forge.pki.privateKeyFromPem(keyPair.toPrivatePem()),
         publicKey: forge.pki.publicKeyFromPem(keyPair.toPublicPem()),
         ...options
       });
@@ -237,7 +237,7 @@ class RSAKeyPair extends LDKeyPair {
             return reject(err);
           }
           resolve(new RSAKeyPair({
-            secretKey: keyPair.privateKey,
+            privateKey: keyPair.privateKey,
             publicKey: keyPair.publicKey,
             ...options
           }));
@@ -248,7 +248,7 @@ class RSAKeyPair extends LDKeyPair {
   static async from(data, options) {
     const keys = new RSAKeyPair({
       publicKey: forge.pki.publicKeyFromPem(data.publicKeyPem),
-      secretKey: forge.pki.privateKeyFromPem(data.secretKeyPem),
+      privateKey: forge.pki.privateKeyFromPem(data.privateKeyPem),
       id: data.id,
       keyType: data.keyType,
       ...options
@@ -264,7 +264,7 @@ class RSAKeyPair extends LDKeyPair {
     };
 
     this.addEncodedPublicKey(keyNode);
-    this.addEncryptedSecretKey(keyNode);
+    this.addEncryptedPrivateKey(keyNode);
 
     return keyNode;
   }
@@ -274,13 +274,13 @@ class RSAKeyPair extends LDKeyPair {
     return publicKeyNode;
   }
 
-  async addEncryptedSecretKey(keyNode) {
+  async addEncryptedPrivateKey(keyNode) {
     if(this.passphrase !== null) {
-      keyNode.secretKeyPem = forge.pki.encryptRsaPrivateKey(
-        this.secretKey, this.passphrase, {algorithm: 'aes256'});
+      keyNode.privateKeyPem = forge.pki.encryptRsaPrivateKey(
+        this.privateKey, this.passphrase, {algorithm: 'aes256'});
     } else {
       // no passphrase, do not encrypt private key
-      keyNode.secretKeyPem = forge.pki.privateKeyToPem(this.secretKey);
+      keyNode.privateKeyPem = forge.pki.privateKeyToPem(this.privateKey);
     }
     return keyNode;
   }

--- a/lib/methods/veres-one/veres-one.js
+++ b/lib/methods/veres-one/veres-one.js
@@ -168,11 +168,11 @@ class VeresOne {
     const invokeKeyId = didDocument.doc.capabilityInvocation[0].publicKey[0].id;
     const creator = invokeKeyId;
     const invokeKey = didDocument.keys[invokeKeyId];
-    if(!invokeKey.secretKey) {
+    if(!invokeKey.privateKey) {
       throw new Error('Invocation key required to perform a send');
     }
 
-    const secretKey = await invokeKey.export();
+    const privateKey = await invokeKey.export();
 
     // attach capability invocation proof
     const capabilityAction = operation.type.startsWith('Create')
@@ -184,8 +184,8 @@ class VeresOne {
       capability: didDocument.id,
       capabilityAction,
       creator,
-      privateKeyPem: secretKey.secretKeyPem,
-      privateKeyBase58: secretKey.secretKeyBase58,
+      privateKeyPem: privateKey.privateKeyPem,
+      privateKeyBase58: privateKey.privateKeyBase58,
     });
 
     const response = await this.client

--- a/tests/dids/did-v1-test-nym-eddsa-example-keys.json
+++ b/tests/dids/did-v1-test-nym-eddsa-example-keys.json
@@ -3,18 +3,18 @@
     "id": "did:v1:test:nym:DfKCjXdt3cKzCsi4EGxhYcYvEa8k1Sz6wBH9MREs3y4r#authn-key-1",
     "keyType": "Ed25519VerificationKey2018",
     "publicKeyBase58": "DfKCjXdt3cKzCsi4EGxhYcYvEa8k1Sz6wBH9MREs3y4r",
-    "secretKeyBase58": "4jtX9P2GRGi7EKoRFvv6hyvhEAJhnbe7rNrEzhGT5uza3bPaXnERpYbypESGHtW4gh6ywY1hF8CgxDwrx2VfeXWW"
+    "privateKeyBase58": "4jtX9P2GRGi7EKoRFvv6hyvhEAJhnbe7rNrEzhGT5uza3bPaXnERpYbypESGHtW4gh6ywY1hF8CgxDwrx2VfeXWW"
   },
   "did:v1:test:nym:DfKCjXdt3cKzCsi4EGxhYcYvEa8k1Sz6wBH9MREs3y4r#ocap-grant-key-1": {
     "id": "did:v1:test:nym:DfKCjXdt3cKzCsi4EGxhYcYvEa8k1Sz6wBH9MREs3y4r#ocap-grant-key-1",
     "keyType": "Ed25519VerificationKey2018",
     "publicKeyBase58": "HKxDmh1xFHz8m3yhJL2WXruBNFXUFEpBKG4rSCVDwfEk",
-    "secretKeyBase58": "3Xc2P6H3dR6r9NAqsc8XPt9eHtDPLVy26uF3DHkmbEdQ7xRjc4HpCjkR3M3WkjejBQpucdYGt26gzKUbfJcCj66p"
+    "privateKeyBase58": "3Xc2P6H3dR6r9NAqsc8XPt9eHtDPLVy26uF3DHkmbEdQ7xRjc4HpCjkR3M3WkjejBQpucdYGt26gzKUbfJcCj66p"
   },
   "did:v1:test:nym:DfKCjXdt3cKzCsi4EGxhYcYvEa8k1Sz6wBH9MREs3y4r#ocap-invoke-key-1": {
     "id": "did:v1:test:nym:DfKCjXdt3cKzCsi4EGxhYcYvEa8k1Sz6wBH9MREs3y4r#ocap-invoke-key-1",
     "keyType": "Ed25519VerificationKey2018",
     "publicKeyBase58": "4dYHzyaMGVFdzVsUF9KoyP8PgvoVQd6E6cbpxM2LL7cT",
-    "secretKeyBase58": "4cCrKuak9UWvUz9zdCkmnmasA3uqz8Ey8F6CtNKgtkjhzrq2MQdfJCzrGTX7VDfuZniq8qmPKrCZ259LoSd5pxAB"
+    "privateKeyBase58": "4cCrKuak9UWvUz9zdCkmnmasA3uqz8Ey8F6CtNKgtkjhzrq2MQdfJCzrGTX7VDfuZniq8qmPKrCZ259LoSd5pxAB"
   }
 }

--- a/tests/ld-key-pair.spec.js
+++ b/tests/ld-key-pair.spec.js
@@ -23,7 +23,7 @@ describe('LDKeyPair', () => {
         expect(exported.id).to.equal('#test-id');
         expect(exported.keyType).to.equal(keyType);
         expect(exported).to.have.property('publicKeyBase58');
-        expect(exported).to.have.property('secretKeyBase58');
+        expect(exported).to.have.property('privateKeyBase58');
       });
     });
 
@@ -51,7 +51,7 @@ describe('LDKeyPair', () => {
         expect(exported.id).to.equal('#test-id');
         expect(exported.keyType).to.equal(keyType);
         expect(exported).to.have.property('publicKeyPem');
-        expect(exported).to.have.property('secretKeyPem');
+        expect(exported).to.have.property('privateKeyPem');
       });
     });
 

--- a/tests/veres-one/veres-did-doc.spec.js
+++ b/tests/veres-one/veres-did-doc.spec.js
@@ -94,11 +94,11 @@ describe('VeresOneDidDoc', () => {
       const keys = await didDoc.exportKeys();
 
       expect(keys[didDoc.id + '#authn-key-1'])
-        .to.have.property('secretKeyBase58');
+        .to.have.property('privateKeyBase58');
       expect(keys[didDoc.id + '#ocap-invoke-key-1'])
-        .to.have.property('secretKeyBase58');
+        .to.have.property('privateKeyBase58');
       expect(keys[didDoc.id + '#ocap-delegate-key-1'])
-        .to.have.property('secretKeyBase58');
+        .to.have.property('privateKeyBase58');
     });
   });
 

--- a/tests/veres-one/veres-one.spec.js
+++ b/tests/veres-one/veres-one.spec.js
@@ -56,7 +56,7 @@ describe('methods/veres-one', () => {
 
       const keyPair = await didDocument.keys[authPublicKey.id].export();
       // check the corresponding private key
-      expect(keyPair.secretKeyPem)
+      expect(keyPair.privateKeyPem)
         .to.have.string('-----BEGIN ENCRYPTED PRIVATE KEY-----');
     }).timeout(30000);
 
@@ -73,7 +73,7 @@ describe('methods/veres-one', () => {
       const exportedKey = await didDocument.keys[authPublicKey.id].export();
 
       // check the corresponding private key
-      expect(exportedKey.secretKeyJwe.unprotected.alg)
+      expect(exportedKey.privateKeyJwe.unprotected.alg)
         .to.equal('PBES2-A128GCMKW');
 
       // check that keys have been saved in key store
@@ -94,7 +94,7 @@ describe('methods/veres-one', () => {
         .to.have.string('-----BEGIN PUBLIC KEY-----');
       const keyPair = await didDocument.keys[authPublicKey.id].export();
       // check the corresponding private key
-      expect(keyPair.secretKeyPem)
+      expect(keyPair.privateKeyPem)
         .to.have.string('-----BEGIN RSA PRIVATE KEY-----');
 
     }).timeout(30000);
@@ -108,7 +108,7 @@ describe('methods/veres-one', () => {
       expect(authPublicKey.publicKeyBase58).to.exist();
 
       const exportedKey = await didDocument.keys[authPublicKey.id].export();
-      expect(exportedKey.secretKeyBase58).to.exist();
+      expect(exportedKey.privateKeyBase58).to.exist();
     }).timeout(30000);
 
     it('should generate uuid-based DID Document', async () => {
@@ -151,12 +151,12 @@ describe('methods/veres-one', () => {
 
       const grantPublicKey = didDocument.doc.capabilityDelegation[0].publicKey[0];
       const creator = grantPublicKey.id;
-      const {secretKeyPem} = await didDocument.keys[grantPublicKey.id].export();
+      const {privateKeyPem} = await didDocument.keys[grantPublicKey.id].export();
 
       didDocument = await v1.attachDelegationProof({
         didDocument,
         creator,
-        privateKeyPem: secretKeyPem
+        privateKeyPem
       });
 
       expect(didDocument.proof).to.exist();
@@ -177,14 +177,14 @@ describe('methods/veres-one', () => {
       const invokePublicKey = didDocument.doc.capabilityInvocation[0].publicKey[0];
       const creator = invokePublicKey.id;
 
-      const {secretKeyPem} = await didDocument.keys[invokePublicKey.id].export();
+      const {privateKeyPem} = await didDocument.keys[invokePublicKey.id].export();
 
       operation = await v1.attachInvocationProof({
         operation,
         capability: didDocument.id,
         capabilityAction: operation.type,
         creator,
-        privateKeyPem: secretKeyPem
+        privateKeyPem
       });
 
       expect(operation.type).to.equal('CreateWebLedgerRecord');
@@ -211,14 +211,14 @@ describe('methods/veres-one', () => {
       let operation = v1.client.wrap({didDocument});
       const invokePublicKey = didDocument.doc.capabilityInvocation[0].publicKey[0];
       const creator = invokePublicKey.id;
-      const {secretKeyPem} = await didDocument.keys[invokePublicKey.id].export();
+      const {privateKeyPem} = await didDocument.keys[invokePublicKey.id].export();
 
       operation = await v1.attachInvocationProof({
         operation,
         capability: didDocument.id,
         capabilityAction: operation.type,
         creator,
-        privateKeyPem: secretKeyPem
+        privateKeyPem
       });
 
       // attach an equihash proof


### PR DESCRIPTION
Renamed `secretKey` to `privateKey` properties, to match Digital Bazaar conventions.
Closes #15.