### PR TITLE
Remove storage docs (no longer used in this lib).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DID Client _(did-io)_
 
 [![Build Status](https://travis-ci.org/digitalbazaar/did-io.png?branch=master)](https://travis-ci.org/digitalbazaar/did-io)
+[![NPM Version](https://img.shields.io/npm/v/did-io.svg?style=flat-square)](https://npm.im/did-io)
 
 > A [DID](https://w3c-ccg.github.io/did-spec/) (Decentralized Identifier) resolution library for Javascript
 
@@ -51,38 +52,6 @@ To install as a dependency in another project, add this to your `package.json`:
 ```
 
 ## Usage
-
-### Setting Up Storage
-
-To work with DIDs, you'll need storage for keys, local DID docs, and
-notes.
-
-**By default, everything is stored in `~/.dids/<method>/<mode>/`, where `mode`
-is `test`/`live` etc.**
-
-DIDs are essentially repositories of public keys on various networks / ledgers.
-Any non-trivial operations that involve them, such as registering, updating,
-authenticating and so on, necessarily involve working with corresponding private
-keys.
-
-To aid with experimentation and development of DID-related prototypes, `did-io`
-uses a simple filesystem based JSON blob storage system, to store private keys,
-local copies of DID documents, and DID metadata on one's local machine.
-
-Keys from DID Documents (as well as related metadata) you control will be stored
-in the `~/.dids/<method>/<mode>/` folder by default, and will be organized by
-DID.
-
-For example for a DID of "did:method:abcd", the following files would be
-potentially created:
-
-- `~/.dids/method/test/did:method:abcd.json`
-- `~/.dids/method/test/did:method:abcd.keys.json`
-- `~/.dids/method/test/did:method:abcd.meta.json`
-
-You can override the storage mechanism for each ledger method (to store JSON
-files in a different directory, or to use an in-memory `MockStore` for unit
-testing).
 
 ### Configuring method-specific drivers
 


### PR DESCRIPTION
This library no longer handles storage. Remove that section of the README (it's been moved to https://github.com/digitalbazaar/did-cli/pull/31, anyways).