### PR TITLE
Remove npm version hooks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,7 @@
   ],
   "scripts": {
     "mocha": "mocha ./tests/**/*.spec.js ./tests/*.spec.js",
-    "test": "npm run mocha",
-    "preversion": "npm test",
-    "postversion": "git push --follow-tags"
+    "test": "npm run mocha"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
- Not used with our release style and already removed in newer branch.

@dmitrizagidulin These small changes for a patch release may require v0.9.0 branch rebase.