### PR TITLE
Implement a resolver.generate() function.

### DIFF
--- a/lib/CachedResolver.js
+++ b/lib/CachedResolver.js
@@ -34,13 +34,13 @@ export class CachedResolver {
    * @param {object} options - Options hashmap.
    * @param {string} [options.did] - DID uri.
    * @param {string} [options.url] - Typically, a key ID or other DID-related
-   *   url. This is used to improve code readability.
-   * @param {object} [options.getOptions] - Options passed through to the
+   *   url. This is used instead of 'did' to improve code readability.
+   * @param {object} [options.args] - Options passed through to the
    *   driver's get() operation.
    *
    * @returns {Promise<object>} Resolves with fetched DID Document.
    */
-  async get({did, url, ...getOptions} = {}) {
+  async get({did, url, ...args} = {}) {
     did = did || url;
     if(!did) {
       throw new TypeError('A string "did" or "url" parameter is required.');
@@ -50,8 +50,27 @@ export class CachedResolver {
 
     return this._cache.memoize({
       key: did,
-      fn: () => method.get({did, ...getOptions})
+      fn: () => method.get({did, ...args})
     });
+  }
+
+  /**
+   * Generates a new DID Document and corresponding keys.
+   *
+   * @param {object} options - Options hashmap.
+   * @param {string} options.method - DID method id (e.g. 'key', 'v1', 'web').
+   * @param {object} options.args - Options passed through to the DID driver.
+   *
+   * @returns {Promise<object>} Resolves with result of individual DID driver's
+   *   `generate()` method call.
+   */
+  async generate({method, ...args}) {
+    const driver = this._methods.get(method);
+    if(!driver) {
+      throw new Error(`Driver for DID method "${method}" not found.`);
+    }
+
+    return driver.generate(args);
   }
 
   /**


### PR DESCRIPTION
Adding a pass-through `.generate()` function. For use with `did-cli` and similar multi-did-method applications.